### PR TITLE
Remove explicit yt and trident dependence

### DIFF
--- a/cloudflex.py
+++ b/cloudflex.py
@@ -7,27 +7,40 @@ import h5py
 import numpy as np
 import numpy.fft
 from math import *
-from optparse import OptionParser
 import sys
 import matplotlib.pyplot as plt
-import cmasher as cmr
 import warnings
 from tqdm import tqdm
-from unyt import kpc, cm, K, amu, km, s, Msun, angstrom, c, g, proton_mass
-import matplotlib as mpl
+from unyt import \
+    kpc, \
+    cm, \
+    K, \
+    amu, \
+    km, \
+    s, \
+    Msun, \
+    angstrom, \
+    c, \
+    g, \
+    proton_mass, \
+    boltzmann_constant_cgs
 import pandas as pd
-from trident_voigt import solar_abundance
-from trident_voigt import tau_profile
-from yt.utilities.physical_constants import boltzmann_constant_cgs
-from astropy.convolution import Gaussian1DKernel, convolve
+from trident_voigt import \
+    solar_abundance, \
+    tau_profile
+from astropy.convolution import \
+    Gaussian1DKernel, \
+    convolve
 import matplotlib.ticker as ticker
-from matplotlib.ticker import MultipleLocator
-from matplotlib.ticker import AutoMinorLocator
-from matplotlib.collections import PatchCollection
-from matplotlib_scalebar.scalebar import ScaleBar
+from matplotlib.ticker import \
+    MultipleLocator, \
+    AutoMinorLocator
+from matplotlib.collections import \
+    PatchCollection
+from matplotlib_scalebar.scalebar import \
+    ScaleBar
 import matplotlib.patheffects as pe
 import matplotlib.gridspec as gridspec
-import palettable
 import cmyt
 import cmocean
 import matplotlib.colors as colors

--- a/cloudflex.py
+++ b/cloudflex.py
@@ -24,7 +24,6 @@ from unyt import \
     g, \
     proton_mass, \
     boltzmann_constant_cgs
-import pandas as pd
 from trident_voigt import \
     solar_abundance, \
     tau_profile
@@ -796,9 +795,6 @@ centers: %s\n velocities: %s\n params: %s""" % (len(self.masses), self.masses[0:
             ax.set_ylabel('log(Velocity Difference (km/s))')
             text = 'Beta: %.2f' % self.params['beta']
             plt.text(0.01, 0.95, text, weight='bold', color='white',transform=ax.transAxes)
-            ## overplot the median
-            #df = bin_by(np.log10(dist[mask]), np.log10(vel_diff[mask]), nbins=50, bins = None)
-            #plt.plot(df.x, df['median'], color = '1', alpha = 0.7, linewidth = 1)
             plt.savefig('turbulence_log.png')
             plt.close()
         return
@@ -1591,44 +1587,6 @@ def plot_multi_histogram(fields, names, label, text=None, x_max=None, log=False,
         plt.text(0.01, 0.95, text, size='medium', weight='bold', color='black',transform=ax.transAxes)
     plt.savefig(filename)
     plt.close("all")
-
-def bin_by(x, y, nbins=30, bins = None):
-    """
-    Divide the x axis into sections and return groups of y based on its x value
-    Code from: https://github.com/tommlogan/watercolor/blob/master/watercolor.py
-    """
-    if bins is None:
-        bins = np.linspace(x.min(), x.max(), nbins)
-
-    bin_space = (bins[-1] - bins[0])/(len(bins)-1)/2
-
-    indicies = np.digitize(x, bins + bin_space)
-
-    output = []
-    for i in range(0, len(bins)):
-        output.append(y[indicies==i])
-    #
-    # prepare a dataframe with cols: median; mean; 1up, 1dn, 2up, 2dn, 3up, 3dn
-    df_names = ['mean', 'median', '5th', '95th', '10th', '90th', '25th', '75th']
-    df = pd.DataFrame(columns = df_names)
-    to_delete = []
-    # for each bin, determine the std ranges
-    for y_set in output:
-        if y_set.size > 0:
-            av = y_set.mean()
-            intervals = np.percentile(y_set, q = [50, 5, 95, 10, 90, 25, 75])
-            res = [av] + list(intervals)
-            df = df.append(pd.DataFrame([res], columns = df_names))
-        else:
-            # just in case there are no elements in the bin
-            to_delete.append(len(df) + 1 + len(to_delete))
-
-
-    # add x values
-    bins = np.delete(bins, to_delete)
-    df['x'] = bins
-
-    return df
 
 def create_and_plot_clouds(params, cloud_fil='clouds.h5'):
     """

--- a/cloudflex.py
+++ b/cloudflex.py
@@ -16,8 +16,8 @@ from tqdm import tqdm
 from unyt import kpc, cm, K, amu, km, s, Msun, angstrom, c, g, proton_mass
 import matplotlib as mpl
 import pandas as pd
-from trident.ion_balance import solar_abundance
-from trident.absorption_spectrum.absorption_line import tau_profile
+from trident_voigt import solar_abundance
+from trident_voigt import tau_profile
 from yt.utilities.physical_constants import boltzmann_constant_cgs
 from astropy.convolution import Gaussian1DKernel, convolve
 import matplotlib.ticker as ticker

--- a/make_all.py
+++ b/make_all.py
@@ -2,7 +2,6 @@ import numpy as np
 from unyt import cm, K, proton_mass
 import os
 import glob
-from IPython import embed
 
 from cloudflex import \
     SpectrumGenerator, \

--- a/trident_voigt.py
+++ b/trident_voigt.py
@@ -1,0 +1,191 @@
+"""
+CloudFlex relies on source code taken from the Trident package to perform
+the absorption line generation.  The code below was extracted directly from
+the Trident source, so as to avoid having Trident+yt as explicit software
+dependencies.
+
+Trident is a python-based package extending yt for generating synthetic
+observations of hydrodynamical datasets.
+
+Please visit the Trident and yt websites for more information:
+http://trident-project.org
+http://yt-project.org
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2016, Trident Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+#-----------------------------------------------------------------------------
+"""
+
+import numpy as np
+from scipy.special import wofz
+from unyt import \
+    charge_proton_cgs, \
+    mass_electron_cgs, \
+    speed_of_light_cgs
+
+tau_factor = None
+_cs = None
+
+# Taken from Cloudy documentation.
+solar_abundance = {
+    'H' : 1.00e+00, 'He': 1.00e-01, 'Li': 2.04e-09,
+    'Be': 2.63e-11, 'B' : 6.17e-10, 'C' : 2.45e-04,
+    'N' : 8.51e-05, 'O' : 4.90e-04, 'F' : 3.02e-08,
+    'Ne': 1.00e-04, 'Na': 2.14e-06, 'Mg': 3.47e-05,
+    'Al': 2.95e-06, 'Si': 3.47e-05, 'P' : 3.20e-07,
+    'S' : 1.84e-05, 'Cl': 1.91e-07, 'Ar': 2.51e-06,
+    'K' : 1.32e-07, 'Ca': 2.29e-06, 'Sc': 1.48e-09,
+    'Ti': 1.05e-07, 'V' : 1.00e-08, 'Cr': 4.68e-07,
+    'Mn': 2.88e-07, 'Fe': 2.82e-05, 'Co': 8.32e-08,
+    'Ni': 1.78e-06, 'Cu': 1.62e-08, 'Zn': 3.98e-08}
+
+def voigt(a, u):
+    """
+    Calculate the numerical Voigt line profile for absorption features.
+
+    This code uses a SciPy routine to numerically calculate the Voigt Profile
+    for deposition as absorption features into spectra.
+
+    This method employs the real part of the Fadeeva function, w(z),
+    shown here as special.wofz.  It operates on a and u, unitless variables
+    representing the frequency/wavelength range and the damping parameter for
+    the line.
+
+    Included are notes from a previous implementation:
+    a = Voigt "A" parameter.
+    u = Frequency in units of the Doppler frequency.
+
+    The line profile "Phi(v)", the doppler width
+    "Delv", the voigt parameter "a", and the frequency "u"
+    are given by:
+
+    Phi(v) =  Voigt(a,u)/[ Delv * sqrt(pi) ]
+    Delv   =  Vo/c * sqrt[ 2kT/m ]
+    u      =  V - Vo / Delv
+    a      =  GAMMA / [ Delv * 4pi ]
+    Gamma  =  Gu + Gl + 2*Vcol
+    "Gu" and "Gl" are the widths of the upper and lower states
+    "Vcol" is the collisions per unit time
+    "Vo" is the line center frequency
+
+    **Parameters**
+
+    :a: float
+
+        Damping parameter or Voigt "A" parameter describing the width of the
+        profile. This is the gamma value divided by the b parameter (thermal
+        broadening) in the unitless frame of the u array.
+
+    :u: array
+
+        The region over which the voigt profile will be calculated. This too
+        is unitless and represents the normalized frequency space over which
+        to calculate the Voigt profile.
+
+    """
+    x = np.asarray(u).astype(np.float64)
+    y = np.asarray(a).astype(np.float64)
+    return wofz(x + 1j * y).real
+
+def tau_profile(lambda_0, f_value, gamma, v_doppler, column_density,
+                delta_v=None, delta_lambda=None,
+                lambda_bins=None, n_lambda=12000, dlambda=0.01):
+    """
+    Make optical depth vs. wavelength profile for an absorption line.
+
+    This method uses the numerical Voigt Profile integrator in the voigt()
+    function to deposit optical depth values for absorption lines into the
+    wavelength space surrounding an absorption feature.
+
+    **Parameters**
+
+    :lambda_0: float
+
+       Central wavelength of absorber in angstroms.
+
+    :f_value: float
+
+       The oscillator strength of the absorption line.
+
+    :gamma: float
+
+       Absorption line gamma value.
+
+    :v_doppler: float
+
+       Doppler b-parameter in cm/s.
+
+    :column_density: float
+
+       Column density in cm^-2.
+
+    :delta_v: float
+
+       Velocity offset from central wavelength (lambda_0) in cm/s.
+       Default: None (no shift).
+
+    :delta_lambda: float
+
+        Wavelength offset from central wavelength (lambda_0) in angstroms.
+        Default: None (no shift).
+
+    :lambda_bins: array
+
+        Wavelength array for line deposition in anstroms.  If None, one will be
+        created using n_lambda and dlambda.
+        Default: None.
+
+    :n_lambda: int
+
+        Number of lambda bins to create if lambda_bins is None.
+        Default: 12000.
+
+    :dlambda: float in angstroms
+
+        Width of lambda bins in angstroms if lambda_bins is None.
+        Default: 0.01.
+
+    """
+    global tau_factor
+    if tau_factor is None:
+        tau_factor = (
+            np.sqrt(np.pi) * charge_proton_cgs ** 2 /
+            (mass_electron_cgs * speed_of_light_cgs)
+        ).in_cgs().d
+
+    global _cs
+    if _cs is None:
+        _cs = speed_of_light_cgs.d[()]
+
+    # shift lambda_0 by delta_v
+    if delta_v is not None:
+        lam1 = lambda_0 * (1 + delta_v / _cs)
+    elif delta_lambda is not None:
+        lam1 = lambda_0 + delta_lambda
+    else:
+        lam1 = lambda_0
+
+    # conversions
+    nudop = 1e8 * v_doppler / lam1   # doppler width in Hz
+
+    # create wavelength
+    if lambda_bins is None:
+        lambda_bins = lam1 + \
+            np.arange(n_lambda, dtype=np.float) * dlambda - \
+            n_lambda * dlambda / 2  # wavelength vector (angstroms)
+
+    # tau_0
+    tau_X = tau_factor * column_density * f_value / v_doppler
+    tau0 = tau_X * lambda_0 * 1e-8
+
+    # dimensionless frequency offset in units of doppler freq
+    u = _cs / v_doppler * (lam1 / lambda_bins - 1.0)
+    a = gamma / (4.0 * np.pi * nudop)               # damping parameter
+    phi = voigt(a, u)                               # line profile
+    tauphi = tau0 * phi              # profile scaled with tau0
+
+    return (lambda_bins, tauphi)


### PR DESCRIPTION
This PR removes yt, trident, and pandas as strict dependencies.  For Trident, it pulls in the relevant code into the cloudflex repo as `trident_voigt.py`.  For yt, we were primarily using it for constants and conversions, which are available from the lightweight `unyt` package, so we're now dependent on that.  For `pandas`, I had been using pandas for a median profiler that was not in use anymore in the turbulence visualization routines, so I just removed it for simplicity.  These have no changes on functionality of code.